### PR TITLE
Commands test

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,55 +1,66 @@
 package main
 
+// TODO(alx): Get rid of copy function.
+
 import (
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 )
 
-type RemoteConn struct {
+type Session struct {
+	Done chan struct{}
 	Conn net.Conn
 	Addr string
 }
 
-type Session struct {
-	Done   chan struct{}
-	Remote RemoteConn
-}
-
-func NewSession(remote net.Conn) *Session {
+func NewSession(conn net.Conn) *Session {
 	return &Session{
-		Done:   make(chan struct{}),
-		Remote: RemoteConn{remote, remote.RemoteAddr().String()},
+		Done: make(chan struct{}),
+		Conn: conn,
+		Addr: conn.RemoteAddr().String(),
 	}
 }
 
-func (s *Session) recv(dst io.Writer, src io.Reader) {
-	_, err := io.Copy(dst, src)
-
+// Just a temporary
+func ignoreErrorForNow(err error) {
 	if err != nil {
 		fmt.Println("Ignore the error for now.")
 	}
-	// CheckError(err) // ignore errors for now.
+}
+
+func (s *Session) recv(src net.Conn) {
+	_, err := io.Copy(os.Stdout, src)
+	ignoreErrorForNow(err)
+	s.Done <- struct{}{}
+}
+
+func (s *Session) send(dest net.Conn) {
+	_, err := io.Copy(dest, os.Stdin)
+	ignoreErrorForNow(err)
 	s.Done <- struct{}{}
 }
 
 func Run(options *Options) {
 	conn, err := net.Dial(options.Network, options.GetAddress(options.Ports[0]))
-	CheckError(err)
-
-	session := NewSession(conn)
+	if err != nil {
+		log.Fatal("Connection aborted", err.Error())
+	}
 
 	defer func() {
 		if err := conn.Close(); err != nil {
-			fmt.Println("Failed to close the connection.")
+			log.Println("Failed to close the connection.")
 		}
 	}()
 
-	fmt.Println("Connected to: ", session.Remote.Addr)
+	session := NewSession(conn)
 
-	go session.recv(os.Stdout, conn)
-	go session.recv(conn, os.Stdin)
+	log.Println("Connected to: ", session.Addr)
+
+	go session.recv(conn)
+	go session.send(conn)
 
 	<-session.Done
 }

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 
 type RemoteConn struct {
 	Conn net.Conn
-	Addr net.Addr
+	Addr string
 }
 
 type Session struct {
@@ -20,7 +20,7 @@ type Session struct {
 func NewSession(remote net.Conn) *Session {
 	return &Session{
 		Done:   make(chan struct{}),
-		Remote: RemoteConn{remote, remote.RemoteAddr()},
+		Remote: RemoteConn{remote, remote.RemoteAddr().String()},
 	}
 }
 
@@ -46,7 +46,7 @@ func Run(options *Options) {
 		}
 	}()
 
-	fmt.Println("Connected to: ", session.Remote.Addr.String())
+	fmt.Println("Connected to: ", session.Remote.Addr)
 
 	go session.recv(os.Stdout, conn)
 	go session.recv(conn, os.Stdin)

--- a/commands.go
+++ b/commands.go
@@ -12,78 +12,93 @@ func MatchCommand(command, match string) bool {
 	return bool(command == match)
 }
 
-func Ls(args []string) []byte {
+func ls(args ...string) []byte {
 	cmd := exec.Command("ls", args...)
 	cmdOut, err := cmd.Output()
 	if err != nil {
-		log.Println(":ls command failed with error: ", err.Error())
-		return []byte{}
+		return []byte("ls command failed\n")
 	}
 	return cmdOut
 }
 
-func Cd(dirname string) []byte {
-	err := os.Chdir(dirname)
-	if err != nil {
-		log.Println(":cd command failed with error: ", err.Error())
-		return []byte{}
+func cd(args ...string) []byte {
+	if len(args) != 0 {
+		err := os.Chdir(args[0])
+		if err != nil {
+			log.Println(":cd command failed with error: ", err.Error())
+			return []byte{}
+		}
+		dir, _ := os.Getwd()
+		return []byte(dir)
 	}
-
-	// Display current working directory back to client.
-	dir, _ := os.Getwd()
-	return []byte(dir)
+	return []byte{}
 }
 
-func Cwd() []byte {
+func cwd(args ...string) []byte {
 	dir, err := os.Getwd()
 	if err != nil {
 		fmt.Println(":cwd command failed with error: ", err.Error())
-		return nil
+		return []byte{}
 	}
 	return []byte(dir)
 }
 
-func Mkdir(dirname string) []byte {
-	err := os.Mkdir(dirname, 0755)
-	if err != nil {
-		log.Println(":mkdir command failed with error: ", err.Error())
+func mkdir(args ...string) []byte {
+	if len(args) != 0 {
+		err := os.Mkdir(args[0], 0755)
+		if err != nil {
+			log.Println(":mkdir command failed with error: ", err.Error())
+			return []byte("Internal server error\n")
+		}
+		return cwd()
 	}
-	return Cwd()
+	return []byte("Directory is not specified\n")
 }
 
-func Rmdir(dirname string) []byte {
-	err := os.RemoveAll(dirname)
-	if err != nil {
-		log.Panic(":rmdir command failed with error: ", err.Error())
+func rmdir(args ...string) []byte {
+	if len(args) != 0 {
+		err := os.RemoveAll(args[0])
+		if err != nil {
+			log.Panic(":rmdir command failed with error: ", err.Error())
+			return []byte("Internal server error\n")
+		}
+		return cwd()
 	}
-	return Cwd()
+	return []byte("Directory is not specified\n")
 }
 
-func Tree() []byte {
+func tree(args ...string) []byte {
 	panic(errors.New("Tree command is not implemented yet."))
 }
 
-func Touch(filename string) {
-	f, err := os.Create(filename)
-	if err != nil {
-		log.Println(":touch command failed with error: ", err.Error())
-		return
+func touch(args ...string) []byte {
+	if len(args) != 0 {
+		f, err := os.Create(args[0])
+		if err != nil {
+			log.Println(":touch command failed with error: ", err.Error())
+			// Return internal server error?
+			return []byte{}
+		}
+		defer f.Close()
 	}
-	defer f.Close()
+	return []byte("file is not specified\n")
 }
 
-func Cat(filepath string) []byte {
-	contents, err := os.ReadFile(filepath)
-	if err != nil {
-		log.Println(":cat command failed with error: ", err.Error())
-		return []byte{}
+func cat(args ...string) []byte {
+	if len(args) != 0 {
+		contents, err := os.ReadFile(args[0])
+		if err != nil {
+			log.Println(":cat command failed with error: ", err.Error())
+			return []byte{}
+		}
+		contents = append(contents, '\n')
+		return contents
 	}
-	contents = append(contents, '\n')
-	return contents
+	return []byte("file doesn't exist\n")
 }
 
 // Very small subset of what rm command actually can support.
-func Rm(args []string) {
+func rm(args ...string) []byte {
 	var handleError = func(err error) {
 		if err != nil {
 			log.Println(":rm command failed with error: ", err.Error())
@@ -116,19 +131,6 @@ func Rm(args []string) {
 		} else {
 			log.Println(":rm Invalid command arguments: ", args)
 		}
-		return
 	}
-}
-
-// Read the file on the server side into a byte array and send to the client.
-func Get(filepath string) *os.File {
-	file, err := os.Open(filepath)
-	if err != nil {
-		log.Println(err)
-		return nil
-	}
-
-	// NOTE(alx): What if we return already closed file descriptor?
-	// defer file.Close()
-	return file
+	return []byte{}
 }

--- a/registry.go
+++ b/registry.go
@@ -4,6 +4,31 @@ import "strings"
 
 type ArrayFlags []string
 
+type CmdHandler func(args []string) []byte
+
+type CmdRegistry struct {
+	commands map[string]CmdHandler
+}
+
+func NewCmdRegistry() *CmdRegistry {
+	return &CmdRegistry{
+		commands: make(map[string]CmdHandler),
+	}
+}
+
+func (r *CmdRegistry) RegisterCommand(cmdName string, handler CmdHandler) {
+	r.commands[cmdName] = handler
+}
+
+func (r *CmdRegistry) ExecuteCommand(cmdName string, args []string) []byte {
+	handler, handlerExists := r.commands[cmdName]
+	if !handlerExists {
+		return []byte("Unknown command\n\n")
+	}
+
+	return handler(args)
+}
+
 // NOTE(alx): This should only contain the data that we want to keep.
 type Options struct {
 	Ports   ArrayFlags

--- a/server.go
+++ b/server.go
@@ -78,6 +78,8 @@ func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
 				tmpRes += cmd + " "
 			}
 			cmdRes = []byte("Current available commands:\n" + tmpRes + "\n\n")
+		} else if command == ":clients" {
+			cmdRes = []byte(fmt.Sprintf("%d online\n\n", len(s.Connections)))
 		} else {
 			cmdRes = cmdReg.ExecuteCommand(command, args)
 		}

--- a/server.go
+++ b/server.go
@@ -3,12 +3,10 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"strings"
 	"sync"
-	"time"
 )
 
 type Peer struct {
@@ -55,7 +53,7 @@ func (s *Server) removeConnection(connId string) {
 	delete(s.Connections, connId)
 }
 
-func (s *Server) processConnection(conn net.Conn) {
+func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
 	peer := s.addConnection(conn)
 	log.Println("Connected peer: ", peer.Addr.String())
 
@@ -74,62 +72,68 @@ func (s *Server) processConnection(conn net.Conn) {
 		command := strings.ToLower(TrimWhitespaces(data[0]))
 		args := data[1:]
 
-		switch {
-		case MatchCommand(command, ":ls"):
-			bytes := Ls(args)
-			conn.Write(bytes)
+		cmdRes := cmdReg.ExecuteCommand(command, args)
+		conn.Write(cmdRes)
 
-		case MatchCommand(command, ":cd"):
-			bytes := Cd(args[0])
-			conn.Write(bytes)
+		// switch {
+		// case MatchCommand(command, ":ls"):
+		// 	bytes := Ls(args)
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":cwd"):
-			bytes := Cwd()
-			conn.Write(bytes)
+		// case MatchCommand(command, ":cd"):
+		// 	bytes := Cd(args[0])
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":cat"):
-			bytes := Cat(args[0])
-			conn.Write(bytes)
+		// case MatchCommand(command, ":cwd"):
+		// 	bytes := Cwd()
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":mkdir"):
-			bytes := Mkdir(args[0])
-			conn.Write(bytes)
+		// case MatchCommand(command, ":cat"):
+		// 	bytes := Cat(args[0])
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":rmdir"):
-			bytes := Rmdir(args[0])
-			conn.Write(bytes)
+		// case MatchCommand(command, ":mkdir"):
+		// 	bytes := Mkdir(args[0])
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":rm"):
-			Rm(args)
+		// case MatchCommand(command, ":rmdir"):
+		// 	bytes := Rmdir(args[0])
+		// 	conn.Write(bytes)
 
-		case MatchCommand(command, ":touch"):
-			filename := TrimWhitespaces(args[0])
-			Touch(filename)
+		// case MatchCommand(command, ":rm"):
+		// 	Rm(args)
 
-		case MatchCommand(command, ":tree"):
-			Tree()
+		// case MatchCommand(command, ":touch"):
+		// 	filename := TrimWhitespaces(args[0])
+		// 	Touch(filename)
 
-		// custom commands:
-		case MatchCommand(command, ":get"):
-			f := Get(args[0])
-			defer f.Close()
-			if f != nil {
-				io.Copy(conn, f)
-			}
+		// case MatchCommand(command, ":tree"):
+		// 	Tree()
 
-		case MatchCommand(command, ":close"):
-			peer.IsConnected = false
-			return
+		// // custom commands:
+		// case MatchCommand(command, ":get"):
+		// 	f := Get(args[0])
+		// 	defer f.Close()
+		// 	if f != nil {
+		// 		io.Copy(conn, f)
+		// 	}
 
-		default:
-			// Let it be echo for now,
-			// but here supposed to be more advanced logic.
-			Echo(conn, input.Text(), 2*time.Second)
-		}
+		// case MatchCommand(command, ":close"):
+		// 	peer.IsConnected = false
+		// 	return
+
+		// default:
+		// 	// Let it be echo for now,
+		// 	// but here supposed to be more advanced logic.
+		// 	Echo(conn, input.Text(), 2*time.Second)
+		// }
 	}
 }
 
 func (s *Server) Run(options *Options) {
+	cmdReg := NewCmdRegistry()
+	cmdReg.RegisterCommand(":ls", Ls)
+
 	var port string
 	if len(options.Ports) != 0 {
 		port = options.Ports[0]
@@ -150,6 +154,6 @@ func (s *Server) Run(options *Options) {
 			fmt.Println("Connection aborted.")
 			continue
 		}
-		go s.processConnection(conn)
+		go s.processConnection(conn, cmdReg)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -67,66 +67,22 @@ func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
 
 	input := bufio.NewScanner(conn)
 	for input.Scan() {
-		// This is cumbersome!
 		data := strings.Split(input.Text(), " ")
 		command := strings.ToLower(TrimWhitespaces(data[0]))
 		args := data[1:]
 
-		cmdRes := cmdReg.ExecuteCommand(command, args)
+		var cmdRes []byte
+		if command == ":commands" {
+			var tmpRes string
+			for cmd := range cmdReg.commands {
+				tmpRes += cmd + " "
+			}
+			cmdRes = []byte("Current available commands:\n" + tmpRes + "\n\n")
+		} else {
+			cmdRes = cmdReg.ExecuteCommand(command, args)
+		}
+
 		conn.Write(cmdRes)
-
-		// switch {
-		// case MatchCommand(command, ":ls"):
-		// 	bytes := Ls(args)
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":cd"):
-		// 	bytes := Cd(args[0])
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":cwd"):
-		// 	bytes := Cwd()
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":cat"):
-		// 	bytes := Cat(args[0])
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":mkdir"):
-		// 	bytes := Mkdir(args[0])
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":rmdir"):
-		// 	bytes := Rmdir(args[0])
-		// 	conn.Write(bytes)
-
-		// case MatchCommand(command, ":rm"):
-		// 	Rm(args)
-
-		// case MatchCommand(command, ":touch"):
-		// 	filename := TrimWhitespaces(args[0])
-		// 	Touch(filename)
-
-		// case MatchCommand(command, ":tree"):
-		// 	Tree()
-
-		// // custom commands:
-		// case MatchCommand(command, ":get"):
-		// 	f := Get(args[0])
-		// 	defer f.Close()
-		// 	if f != nil {
-		// 		io.Copy(conn, f)
-		// 	}
-
-		// case MatchCommand(command, ":close"):
-		// 	peer.IsConnected = false
-		// 	return
-
-		// default:
-		// 	// Let it be echo for now,
-		// 	// but here supposed to be more advanced logic.
-		// 	Echo(conn, input.Text(), 2*time.Second)
-		// }
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -3,10 +3,13 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 type Peer struct {
@@ -16,12 +19,38 @@ type Peer struct {
 	IsConnected bool
 }
 
+// This is your command registry.
+// And then commands.go will be renamed to cli.go and be part of a server package,
+// since it's server specific.
+// But we can go the other way around and do commands validation on the client side,
+// and ONLY send correct commands with their arguments over the network.
+// It will help to handle cases like (mkdir <dirname> & cd <dirname> etc.)
+
+type CommandHandler func(args ...string) []byte
+type Cli struct {
+	commandRegistry map[string]CommandHandler
+}
+
 type Server struct {
 	Connections map[string]*Peer
+	cli         *Cli // maybe not a pointer, didn't have enough time to think about it.
 	Mu          sync.Mutex
 }
 
 var server *Server
+
+func (cli *Cli) registerCommand(command string, handler CommandHandler) {
+	cli.commandRegistry[command] = handler
+}
+
+func (cli *Cli) getHandler(command string) (CommandHandler, bool) {
+	// I would make it as simple as possible, so it just returns a handle.
+	h, exists := cli.commandRegistry[command]
+	if exists {
+		return h, true
+	}
+	return nil, false
+}
 
 func NewPeer(connection net.Conn) *Peer {
 	addr := connection.RemoteAddr()
@@ -34,12 +63,29 @@ func NewPeer(connection net.Conn) *Peer {
 }
 
 func NewServer() *Server {
-	return &Server{
+	s := Server{
 		Connections: make(map[string]*Peer),
+		cli: &Cli{
+			commandRegistry: make(map[string]CommandHandler),
+		},
 	}
+
+	// Register all the commans that can be executed on a server.
+	// We can add custom commands as well, but a handler would be different.
+	s.cli.registerCommand(":ls", ls)
+	s.cli.registerCommand(":cd", cd)
+	s.cli.registerCommand(":cwd", cwd)
+	s.cli.registerCommand(":cat", cat)
+	s.cli.registerCommand(":mkdir", mkdir)
+	s.cli.registerCommand(":rmdir", rmdir)
+	s.cli.registerCommand(":rm", rm)
+	s.cli.registerCommand(":touch", touch)
+
+	return &s
 }
 
 func (s *Server) addConnection(conn net.Conn) *Peer {
+	log.Println("Added new connection")
 	s.Mu.Lock()
 	defer s.Mu.Unlock()
 	peer := NewPeer(conn)
@@ -53,16 +99,16 @@ func (s *Server) removeConnection(connId string) {
 	delete(s.Connections, connId)
 }
 
-func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
-	peer := s.addConnection(conn)
-	log.Println("Connected peer: ", peer.Addr.String())
+func (s *Server) processConnection(conn net.Conn) {
+	curPeer := s.addConnection(conn) // pointer might change its address as we add more connections.
+	log.Println("Connected peer: ", curPeer.Addr.String())
 
 	defer func() {
 		if err := conn.Close(); err != nil {
-			log.Println("Failed to close the connection: ", peer.Addr.String())
+			log.Println("Failed to close the connection: ", curPeer.Addr.String())
 		}
-		s.removeConnection(peer.Id)
-		fmt.Println("Peer disconnected: ", peer.Addr.String())
+		s.removeConnection(curPeer.Id)
+		fmt.Println("Peer disconnected: ", curPeer.Addr.String())
 	}()
 
 	input := bufio.NewScanner(conn)
@@ -71,20 +117,54 @@ func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
 		command := strings.ToLower(TrimWhitespaces(data[0]))
 		args := data[1:]
 
-		var cmdRes []byte
-		if command == ":help" {
-			var tmpRes string
-			for cmd := range cmdReg.commands {
-				tmpRes += cmd + " "
-			}
-			cmdRes = []byte("Current available commands:\n" + tmpRes + "\n\n")
-		} else if command == ":clients" {
-			cmdRes = []byte(fmt.Sprintf("%d online\n\n", len(s.Connections)))
+		// NOTE: This is not a final version, because if we want to handle edge cases like this:
+		// mkdir <dirname> & cd <dirname> we would have to parse the whole string and break it down into tokens.
+		if handler, exist := s.cli.getHandler(command); exist {
+			log.Println("Invoking :ls command")
+			conn.Write(handler(args...))
 		} else {
-			cmdRes = cmdReg.ExecuteCommand(command, args)
-		}
+			switch {
 
-		conn.Write(cmdRes)
+			case MatchCommand(command, ":ftp"):
+				// get file name from the host, returns only bytes for now.
+				if len(args) == 0 {
+					conn.Write([]byte("File is not specified\n"))
+					continue
+				}
+
+				f, err := os.Open(args[0])
+				if err != nil {
+					conn.Write([]byte("File doesn't exist\n"))
+				} else {
+					defer f.Close()
+					io.Copy(conn, f)
+				}
+
+			case MatchCommand(command, ":close"):
+				// close the connection
+				curPeer.IsConnected = false
+				return
+
+			case MatchCommand(command, ":echo"):
+				// Invoke echo server
+				Echo(conn, strings.Join(args, " "), 2*time.Second)
+
+			case MatchCommand(command, ":send"):
+				// NOTE(alx): If we want to send file from one client to another,
+				// It should come through the server, since we don't support client-to-client communication.
+				// Support P2P? The problem with that would be is that client knows nothing about other clients.
+				// But on the other hand, it will speed up the process of transferring the files and messages.
+				panic("Sending files to different clients is not implemented yet.")
+
+			default:
+				// Send messages to all clients.
+				for _, peer := range s.Connections {
+					if curPeer.Id != peer.Id {
+						peer.Conn.Write([]byte(input.Text()))
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -72,7 +72,7 @@ func (s *Server) processConnection(conn net.Conn, cmdReg *CmdRegistry) {
 		args := data[1:]
 
 		var cmdRes []byte
-		if command == ":commands" {
+		if command == ":help" {
 			var tmpRes string
 			for cmd := range cmdReg.commands {
 				tmpRes += cmd + " "

--- a/test_cli.go
+++ b/test_cli.go
@@ -1,0 +1,3 @@
+package main
+
+//  Here supposed to be tests for already established commands.


### PR DESCRIPTION
1. Changed client address representation from `net.Addr` to just string
2. Added command registry to register and execute available commands (just prototype, used only with `LS` command)